### PR TITLE
fix: do not depend on `puppeteer-core`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.12.10",
     "@types/puppeteer": "^1.10.0",
-    "@types/puppeteer-core": "^1.9.0",
     "@types/sinon": "^5.0.7",
     "@types/test-listen": "^1.1.0",
     "chai": "^4.2.0",

--- a/src/axePuppeteer.ts
+++ b/src/axePuppeteer.ts
@@ -1,5 +1,5 @@
 import * as Axe from 'axe-core'
-import { Browser, Frame, Page } from 'puppeteer-core'
+import { Browser, Frame, Page } from 'puppeteer'
 import { pageIsLoaded, runAxe } from './browser'
 import { AnalyzeCB } from './types'
 

--- a/src/owning.ts
+++ b/src/owning.ts
@@ -1,5 +1,5 @@
 import * as Axe from 'axe-core'
-import { Browser, Page } from 'puppeteer-core'
+import { Browser, Page } from 'puppeteer'
 import { AxePuppeteer } from './axePuppeteer'
 import { AnalyzeCB, IPageOptions } from './types'
 


### PR DESCRIPTION
This patch removes our dependency on `puppeteer-core`, since the same classes are exported by `puppeteer` (which we have listed as a peer dependency).