### PR TITLE
chore(package): remove unused dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -354,18 +354,6 @@
         "negotiator": "0.6.1"
       }
     },
-    "acorn": {
-      "version": "6.0.4",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/acorn/-/acorn-6.0.4.tgz",
-      "integrity": "sha1-dzd+c1O3LsUQRVCqLSCXov1At1Q=",
-      "dev": true
-    },
-    "acorn-jsx": {
-      "version": "5.0.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/acorn-jsx/-/acorn-jsx-5.0.0.tgz",
-      "integrity": "sha1-lYWE3bYJkMAsl8G9nVIfzkM7sQE=",
-      "dev": true
-    },
     "agent-base": {
       "version": "4.2.1",
       "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/agent-base/-/agent-base-4.2.1.tgz",
@@ -373,18 +361,6 @@
       "dev": true,
       "requires": {
         "es6-promisify": "^5.0.0"
-      }
-    },
-    "ajv": {
-      "version": "6.5.5",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/ajv/-/ajv-6.5.5.tgz",
-      "integrity": "sha1-z5fNreccY5mpLG1sQXc4EpG3gaE=",
-      "dev": true,
-      "requires": {
-        "fast-deep-equal": "^2.0.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
       }
     },
     "ansi-escapes": {
@@ -734,21 +710,6 @@
         }
       }
     },
-    "caller-path": {
-      "version": "0.1.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/caller-path/-/caller-path-0.1.0.tgz",
-      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true,
-      "requires": {
-        "callsites": "^0.2.0"
-      }
-    },
-    "callsites": {
-      "version": "0.2.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/callsites/-/callsites-0.2.0.tgz",
-      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
-      "dev": true
-    },
     "chai": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
@@ -794,12 +755,6 @@
         }
       }
     },
-    "chardet": {
-      "version": "0.7.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha1-kAlISfCTfy7twkJdDSip5fDLrZ4=",
-      "dev": true
-    },
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
@@ -810,12 +765,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
       "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
-      "dev": true
-    },
-    "circular-json": {
-      "version": "0.3.3",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
       "dev": true
     },
     "class-utils": {
@@ -887,12 +836,6 @@
           }
         }
       }
-    },
-    "cli-width": {
-      "version": "2.2.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/cli-width/-/cli-width-2.2.0.tgz",
-      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
-      "dev": true
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -1051,12 +994,6 @@
       "requires": {
         "type-detect": "^4.0.0"
       }
-    },
-    "deep-is": {
-      "version": "0.1.3",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
     },
     "define-property": {
       "version": "2.0.2",
@@ -1218,148 +1155,10 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
-    "eslint": {
-      "version": "5.9.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/eslint/-/eslint-5.9.0.tgz",
-      "integrity": "sha1-sjS20V74S1hJxt4q9DGVotWdQI4=",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "ajv": "^6.5.3",
-        "chalk": "^2.1.0",
-        "cross-spawn": "^6.0.5",
-        "debug": "^4.0.1",
-        "doctrine": "^2.1.0",
-        "eslint-scope": "^4.0.0",
-        "eslint-utils": "^1.3.1",
-        "eslint-visitor-keys": "^1.0.0",
-        "espree": "^4.0.0",
-        "esquery": "^1.0.1",
-        "esutils": "^2.0.2",
-        "file-entry-cache": "^2.0.0",
-        "functional-red-black-tree": "^1.0.1",
-        "glob": "^7.1.2",
-        "globals": "^11.7.0",
-        "ignore": "^4.0.6",
-        "imurmurhash": "^0.1.4",
-        "inquirer": "^6.1.0",
-        "is-resolvable": "^1.1.0",
-        "js-yaml": "^3.12.0",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.3.0",
-        "lodash": "^4.17.5",
-        "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.1",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.8.2",
-        "path-is-inside": "^1.0.2",
-        "pluralize": "^7.0.0",
-        "progress": "^2.0.0",
-        "regexpp": "^2.0.1",
-        "require-uncached": "^1.0.3",
-        "semver": "^5.5.1",
-        "strip-ansi": "^4.0.0",
-        "strip-json-comments": "^2.0.1",
-        "table": "^5.0.2",
-        "text-table": "^0.2.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "debug": {
-          "version": "4.1.0",
-          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/debug/-/debug-4.1.0.tgz",
-          "integrity": "sha1-NzaHv/pnizixzZH4YbY4UANd3Ic=",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "doctrine": {
-          "version": "2.1.0",
-          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/doctrine/-/doctrine-2.1.0.tgz",
-          "integrity": "sha1-XNAfwQFiG0LEzX9dGmYkNxbT850=",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
-      }
-    },
-    "eslint-scope": {
-      "version": "4.0.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/eslint-scope/-/eslint-scope-4.0.0.tgz",
-      "integrity": "sha1-UL8wcekzi83EMzF5Sgy1M/ATYXI=",
-      "dev": true,
-      "requires": {
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
-      }
-    },
-    "eslint-utils": {
-      "version": "1.3.1",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/eslint-utils/-/eslint-utils-1.3.1.tgz",
-      "integrity": "sha1-moUbqJ7nxGA0b5fPiTnHKYgn5RI=",
-      "dev": true
-    },
-    "eslint-visitor-keys": {
-      "version": "1.0.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha1-PzGA+y4pEBdxastMnW1bXDSmqB0=",
-      "dev": true
-    },
-    "espree": {
-      "version": "4.1.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/espree/-/espree-4.1.0.tgz",
-      "integrity": "sha1-co1UUeD9FWwEOEp62J7VH/VOsl8=",
-      "dev": true,
-      "requires": {
-        "acorn": "^6.0.2",
-        "acorn-jsx": "^5.0.0",
-        "eslint-visitor-keys": "^1.0.0"
-      }
-    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
-      "dev": true
-    },
-    "esquery": {
-      "version": "1.0.1",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/esquery/-/esquery-1.0.1.tgz",
-      "integrity": "sha1-QGxRZYsfWZGl+bYrHcJbAOPlxwg=",
-      "dev": true,
-      "requires": {
-        "estraverse": "^4.0.0"
-      }
-    },
-    "esrecurse": {
-      "version": "4.2.1",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/esrecurse/-/esrecurse-4.2.1.tgz",
-      "integrity": "sha1-AHo7n9vCs7uH5IeeoZyS/b05Qs8=",
-      "dev": true,
-      "requires": {
-        "estraverse": "^4.1.0"
-      }
-    },
-    "estraverse": {
-      "version": "4.2.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
       "dev": true
     },
     "esutils": {
@@ -1515,17 +1314,6 @@
         }
       }
     },
-    "external-editor": {
-      "version": "3.0.3",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/external-editor/-/external-editor-3.0.3.tgz",
-      "integrity": "sha1-WGbbKal4Jtvkvzr9JAcOrZ6kOic=",
-      "dev": true,
-      "requires": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
-      }
-    },
     "extglob": {
       "version": "2.0.4",
       "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/extglob/-/extglob-2.0.4.tgz",
@@ -1620,24 +1408,6 @@
         }
       }
     },
-    "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-      "dev": true
-    },
-    "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
-    },
-    "fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
-    },
     "fd-slicer": {
       "version": "1.0.1",
       "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/fd-slicer/-/fd-slicer-1.0.1.tgz",
@@ -1654,16 +1424,6 @@
       "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
-      }
-    },
-    "file-entry-cache": {
-      "version": "2.0.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-      "dev": true,
-      "requires": {
-        "flat-cache": "^1.2.1",
-        "object-assign": "^4.0.1"
       }
     },
     "fill-range": {
@@ -1736,18 +1496,6 @@
         "locate-path": "^3.0.0"
       }
     },
-    "flat-cache": {
-      "version": "1.3.4",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/flat-cache/-/flat-cache-1.3.4.tgz",
-      "integrity": "sha1-LC73dSXMKSkAff/6HdMUqpyd7m8=",
-      "dev": true,
-      "requires": {
-        "circular-json": "^0.3.1",
-        "graceful-fs": "^4.1.2",
-        "rimraf": "~2.6.2",
-        "write": "^0.2.1"
-      }
-    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/for-in/-/for-in-1.0.2.tgz",
@@ -1779,12 +1527,6 @@
       "version": "1.0.0",
       "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
-    },
-    "functional-red-black-tree": {
-      "version": "1.0.1",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
     "g-status": {
@@ -1871,12 +1613,6 @@
           "dev": true
         }
       }
-    },
-    "graceful-fs": {
-      "version": "4.1.15",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/graceful-fs/-/graceful-fs-4.1.15.tgz",
-      "integrity": "sha1-/7cD4QZuig7qpMi4C6klPu77+wA=",
-      "dev": true
     },
     "growl": {
       "version": "1.10.5",
@@ -1983,21 +1719,6 @@
         "slash": "^2.0.0"
       }
     },
-    "iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
-      "dev": true,
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      }
-    },
-    "ignore": {
-      "version": "4.0.6",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/ignore/-/ignore-4.0.6.tgz",
-      "integrity": "sha1-dQ49tYYgh7RzfrrIIH/9HvJ7Jfw=",
-      "dev": true
-    },
     "import-fresh": {
       "version": "2.0.0",
       "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/import-fresh/-/import-fresh-2.0.0.tgz",
@@ -2025,12 +1746,6 @@
         }
       }
     },
-    "imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true
-    },
     "indent-string": {
       "version": "3.2.0",
       "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/indent-string/-/indent-string-3.2.0.tgz",
@@ -2052,44 +1767,6 @@
       "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
-    },
-    "inquirer": {
-      "version": "6.2.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/inquirer/-/inquirer-6.2.0.tgz",
-      "integrity": "sha1-Ua3Nd29mE2ncHolIWcJWCiJKvdg=",
-      "dev": true,
-      "requires": {
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.0",
-        "cli-cursor": "^2.1.0",
-        "cli-width": "^2.0.0",
-        "external-editor": "^3.0.0",
-        "figures": "^2.0.0",
-        "lodash": "^4.17.10",
-        "mute-stream": "0.0.7",
-        "run-async": "^2.2.0",
-        "rxjs": "^6.1.0",
-        "string-width": "^2.1.0",
-        "strip-ansi": "^4.0.0",
-        "through": "^2.3.6"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
-      }
     },
     "ipaddr.js": {
       "version": "1.8.0",
@@ -2299,12 +1976,6 @@
       "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
       "dev": true
     },
-    "is-resolvable": {
-      "version": "1.1.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/is-resolvable/-/is-resolvable-1.1.0.tgz",
-      "integrity": "sha1-+xj4fOH+uSUWnJpAfBkxijIG7Yg=",
-      "dev": true
-    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/is-stream/-/is-stream-1.1.0.tgz",
@@ -2402,18 +2073,6 @@
       "integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk=",
       "dev": true
     },
-    "json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
-      "dev": true
-    },
-    "json-stable-stringify-without-jsonify": {
-      "version": "1.0.1",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
-      "dev": true
-    },
     "just-extend": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-3.0.0.tgz",
@@ -2431,16 +2090,6 @@
       "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/leven/-/leven-2.1.0.tgz",
       "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
       "dev": true
-    },
-    "levn": {
-      "version": "0.3.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
-      }
     },
     "lint-staged": {
       "version": "8.0.5",
@@ -2828,12 +2477,6 @@
       "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo=",
       "dev": true
     },
-    "mute-stream": {
-      "version": "0.0.7",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-      "dev": true
-    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -2852,12 +2495,6 @@
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.1"
       }
-    },
-    "natural-compare": {
-      "version": "1.4.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-      "dev": true
     },
     "negotiator": {
       "version": "0.6.1",
@@ -4175,26 +3812,6 @@
         "mimic-fn": "^1.0.0"
       }
     },
-    "optionator": {
-      "version": "0.8.2",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/optionator/-/optionator-0.8.2.tgz",
-      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true,
-      "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
-      }
-    },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
-    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/p-finally/-/p-finally-1.0.0.tgz",
@@ -4340,22 +3957,10 @@
         "semver-compare": "^1.0.0"
       }
     },
-    "pluralize": {
-      "version": "7.0.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/pluralize/-/pluralize-7.0.0.tgz",
-      "integrity": "sha1-KYuJ34uTsCIdv0Ia0rGx6iP8Z3c=",
-      "dev": true
-    },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
-      "dev": true
-    },
-    "prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
     "prettier": {
@@ -4428,12 +4033,6 @@
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
       }
-    },
-    "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
-      "dev": true
     },
     "puppeteer": {
       "version": "1.10.0",
@@ -4522,12 +4121,6 @@
         "safe-regex": "^1.1.0"
       }
     },
-    "regexpp": {
-      "version": "2.0.1",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/regexpp/-/regexpp-2.0.1.tgz",
-      "integrity": "sha1-jRnTHPYySCtYkEn4KB+T28uk0H8=",
-      "dev": true
-    },
     "repeat-element": {
       "version": "1.1.3",
       "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/repeat-element/-/repeat-element-1.1.3.tgz",
@@ -4540,16 +4133,6 @@
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
-    "require-uncached": {
-      "version": "1.0.3",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/require-uncached/-/require-uncached-1.0.3.tgz",
-      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true,
-      "requires": {
-        "caller-path": "^0.1.0",
-        "resolve-from": "^1.0.0"
-      }
-    },
     "resolve": {
       "version": "1.8.1",
       "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/resolve/-/resolve-1.8.1.tgz",
@@ -4558,12 +4141,6 @@
       "requires": {
         "path-parse": "^1.0.5"
       }
-    },
-    "resolve-from": {
-      "version": "1.0.1",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/resolve-from/-/resolve-from-1.0.1.tgz",
-      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
-      "dev": true
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -4594,15 +4171,6 @@
       "dev": true,
       "requires": {
         "glob": "^7.0.5"
-      }
-    },
-    "run-async": {
-      "version": "2.3.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/run-async/-/run-async-2.3.0.tgz",
-      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-      "dev": true,
-      "requires": {
-        "is-promise": "^2.1.0"
       }
     },
     "run-node": {
@@ -4812,15 +4380,6 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
       "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
       "dev": true
-    },
-    "slice-ansi": {
-      "version": "1.0.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/slice-ansi/-/slice-ansi-1.0.0.tgz",
-      "integrity": "sha1-BE8aSdiEL/MHqta1Be0Xi9lQE00=",
-      "dev": true,
-      "requires": {
-        "is-fullwidth-code-point": "^2.0.0"
-      }
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -5135,12 +4694,6 @@
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
-    "strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "dev": true
-    },
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/supports-color/-/supports-color-2.0.0.tgz",
@@ -5153,18 +4706,6 @@
       "integrity": "sha1-wiaIrtTqs83C3+rLtWFmBWCgCAQ=",
       "dev": true
     },
-    "table": {
-      "version": "5.1.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/table/-/table-5.1.0.tgz",
-      "integrity": "sha1-aaVGRPbwGtFij4F4cVtAjca/Efc=",
-      "dev": true,
-      "requires": {
-        "ajv": "^6.5.3",
-        "lodash": "^4.17.10",
-        "slice-ansi": "1.0.0",
-        "string-width": "^2.1.1"
-      }
-    },
     "test-listen": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/test-listen/-/test-listen-1.1.0.tgz",
@@ -5176,27 +4717,6 @@
       "resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
       "dev": true
-    },
-    "text-table": {
-      "version": "0.2.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-      "dev": true
-    },
-    "through": {
-      "version": "2.3.8",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
-    },
-    "tmp": {
-      "version": "0.0.33",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
-      "dev": true,
-      "requires": {
-        "os-tmpdir": "~1.0.2"
-      }
     },
     "to-fast-properties": {
       "version": "2.0.0",
@@ -5345,26 +4865,6 @@
         }
       }
     },
-    "tslint-no-unused-expression-chai": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/tslint-no-unused-expression-chai/-/tslint-no-unused-expression-chai-0.1.4.tgz",
-      "integrity": "sha512-frEWKNTcq7VsaWKgUxMDOB2N/cmQadVkUtUGIut+2K4nv/uFXPfgJyPjuNC/cHyfUVqIkHMAvHOCL+d/McU3nQ==",
-      "dev": true,
-      "requires": {
-        "tsutils": "^3.0.0"
-      },
-      "dependencies": {
-        "tsutils": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.5.1.tgz",
-          "integrity": "sha512-g9kwRQRpVDhjS3qfrDsnYv7QkBtsNRm1Ln5539hq9Y2ysndnlaWf8+3zTdaa1YB5ko7dpV9XATlP0KmYPsLc+Q==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.8.1"
-          }
-        }
-      }
-    },
     "tsutils": {
       "version": "2.29.0",
       "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/tsutils/-/tsutils-2.29.0.tgz",
@@ -5372,15 +4872,6 @@
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"
-      }
-    },
-    "type-check": {
-      "version": "0.3.2",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "~1.1.2"
       }
     },
     "type-detect": {
@@ -5492,15 +4983,6 @@
         }
       }
     },
-    "uri-js": {
-      "version": "4.2.2",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
-      "dev": true,
-      "requires": {
-        "punycode": "^2.1.0"
-      }
-    },
     "urix": {
       "version": "0.1.0",
       "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/urix/-/urix-0.1.0.tgz",
@@ -5550,12 +5032,6 @@
         "isexe": "^2.0.0"
       }
     },
-    "wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-      "dev": true
-    },
     "wrap-ansi": {
       "version": "3.0.1",
       "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
@@ -5588,15 +5064,6 @@
       "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
-    },
-    "write": {
-      "version": "0.2.1",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/write/-/write-0.2.1.tgz",
-      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-      "dev": true,
-      "requires": {
-        "mkdirp": "^0.5.1"
-      }
     },
     "ws": {
       "version": "5.2.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "@types/sinon": "^5.0.7",
     "@types/test-listen": "^1.1.0",
     "chai": "^4.2.0",
-    "eslint": "^5.9.0",
     "express": "^4.16.4",
     "husky": "^1.2.0",
     "lint-staged": "^8.0.5",
@@ -39,7 +38,6 @@
     "tslint": "^5.11.0",
     "tslint-config-prettier": "^1.16.0",
     "tslint-config-standard": "^8.0.1",
-    "tslint-no-unused-expression-chai": "^0.1.4",
     "typescript": "^3.1.6"
   },
   "dependencies": {


### PR DESCRIPTION
This patch removes 2 unused packages from our dependencies (`eslint` and `tslint-no-unused-expression-chai`).