### PR TITLE
docs: Fix example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,19 @@ Here is an example of a script that will drive Puppeteer to this repository, per
 const { AxePuppeteer } = require('axe-puppeteer')
 const puppeteer = require('puppeteer')
 
-// ... In async function
-const browser = await puppeteer.launch()
-const page = await browser.newPage()
-await page.setBypassCSP(true)
+;(async () => {
+    const browser = await puppeteer.launch()
+    const page = await browser.newPage()
+    await page.setBypassCSP(true)
 
-await page.goto('https://dequeuniversity.com/demo/mars/')
+    await page.goto('https://dequeuniversity.com/demo/mars/')
 
-const results = await new AxePuppeteer(page).analyze()
-console.log(results)
+    const results = await new AxePuppeteer(page).analyze()
+    console.log(results)
+
+    await page.close()
+    await browser.close()
+})()
 ```
 
 Note: Usage examples make use of ES2017 async/await. Use of `await` can only be done in a function
@@ -55,14 +59,17 @@ It closes the page after `analyze` is called.
 const { loadPage } = require('axe-puppeteer')
 const puppeteer = require('puppeteer')
 
-// ... In async function
-const browser = await puppeteer.launch()
-const axeBuilder = await loadPage(
-  browser,
-  'https://dequeuniversity.com/demo/mars/'
-)
-const results = await axeBuilder.analyze()
-console.log(results)
+;(async () => {
+    const browser = await puppeteer.launch()
+    const axeBuilder = await loadPage(
+      browser,
+      'https://dequeuniversity.com/demo/mars/'
+    )
+    const results = await axeBuilder.analyze()
+    console.log(results)
+
+    await browser.close()
+})()
 ```
 
 ### AxePuppeteer(page: Frame | Page[, axeSource: string])

--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ This module uses a chainable API to assist in injecting, configuring and analyzi
 Here is an example of a script that will drive Puppeteer to this repository, perform analysis and then log results to the console.
 
 ```js
-const AxePuppeteer = require('axe-puppeteer')
+const { AxePuppeteer } = require('axe-puppeteer')
 const puppeteer = require('puppeteer')
 
+// ... In async function
 const browser = await puppeteer.launch()
 const page = await browser.newPage()
 await page.setBypassCSP(true)
@@ -54,6 +55,7 @@ It closes the page after `analyze` is called.
 const { loadPage } = require('axe-puppeteer')
 const puppeteer = require('puppeteer')
 
+// ... In async function
 const browser = await puppeteer.launch()
 const axeBuilder = await loadPage(
   browser,


### PR DESCRIPTION
Example didn't account for `axe-puppeteer` exporting multiple things. Also added comments about the context of the example code. Seems like `export default` stopped working at some point, since I know the code used to work.

Closes issue:

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Follows the commit message policy, appropriate for next version
- [ ] Has documentation updated, a DU ticket, or requires no documentation change
- [ ] Includes new tests, or was unnecessary
- [ ] Code is reviewed for security by: << Name here >>