### PR TITLE
feat: update axe-core to v3.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -470,9 +470,9 @@
       "dev": true
     },
     "axe-core": {
-      "version": "3.1.2",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/axe-core/-/axe-core-3.1.2.tgz",
-      "integrity": "sha1-ygr/iX6+/KdVL5eFncEhfAbE+eY="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.3.1.tgz",
+      "integrity": "sha512-gw1T0JptHPF4AdLLqE8yQq3Z7YvsYkpFmFWd84r6hnq/QoKRr8icYHFumhE7wYl5TVIHgVlchMyJsAYh0CfwCQ=="
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -2615,6 +2615,7 @@
           "resolved": false,
           "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -2984,7 +2985,8 @@
           "version": "1.1.6",
           "resolved": false,
           "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -3080,6 +3082,7 @@
           "resolved": false,
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -3132,7 +3135,8 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -3435,7 +3439,8 @@
           "version": "1.6.1",
           "resolved": false,
           "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "require-directory": {
           "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "typescript": "^3.1.6"
   },
   "dependencies": {
-    "axe-core": "^3.1.2"
+    "axe-core": "^3.3.1"
   },
   "peerDependencies": {
     "puppeteer": "^1.10.0"


### PR DESCRIPTION
- Update axe-core to v3.3.1

> Starting to use `axe-puppeteer` for auto-generating some implementation reports in [ACT Rules](https://github.com/act-rules/act-rules-implementation-axe-core/compare/autogen?expand=1#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R23), hence doing some updates here.

Closes issue:
- NA

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security