### PR TITLE
Revert "chore(deps-dev): bump @types/puppeteer from 1.10.0 to 1.19.1"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -303,9 +303,9 @@
       "dev": true
     },
     "@types/puppeteer": {
-      "version": "1.19.1",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/@types/puppeteer/-/puppeteer-1.19.1.tgz",
-      "integrity": "sha1-lCymIoiVOg9fu8JcEDtfK6KLYKs=",
+      "version": "1.10.0",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/@types/puppeteer/-/puppeteer-1.10.0.tgz",
+      "integrity": "sha1-FdU4nW1d7Xv8CwYofoVlWZT4uts=",
       "dev": true,
       "requires": {
         "@types/node": "*"


### PR DESCRIPTION
Reverts dequelabs/axe-puppeteer#35

this is breaking #50 