### PR TITLE
Allow puppeteer@2 in peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "axe-core": "^3.3.1"
   },
   "peerDependencies": {
-    "puppeteer": "^1.10.0"
+    "puppeteer": "^1.10.0 || ^2.0.0"
   },
   "engines": {
     "node": ">=6.4.0"


### PR DESCRIPTION
`axe-puppeteer` seems to work just OK with puppeteer@2. None of the [breaking changes](https://github.com/puppeteer/puppeteer/releases/tag/v2.0.0) look relevant
