### PR TITLE
Allow future Puppeteer versions in peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "axe-core": "^3.5.3"
   },
   "peerDependencies": {
-    "puppeteer": "^1.10.0 || ^2.0.0"
+    "puppeteer": ">=1.10.0"
   },
   "engines": {
     "node": ">=6.4.0"


### PR DESCRIPTION
Puppeteer releases major versions [quite often](https://github.com/puppeteer/puppeteer/releases), so it may be more practical to use `>=` range in peer dependencies

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for accessibility
- [x] Code is reviewed for security